### PR TITLE
Add PacE AID website auditing tool

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,18 @@
+name: Python package
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[test]
+      - name: Run tests
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+
+# Env
+venv/
+.env
+
+# Data
+index.json

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# PacE_web_audit
+# PacE Web Audit
+
+PacE AID (Artificial Intelligence Dean) is a tool for crawling and auditing the UCSB Professional and Continuing Education websites.
+
+## Features
+- Crawl and index pages from the following domains:
+  - https://www.professional.ucsb.edu/
+  - https://help.professional.ucsb.edu/
+  - https://enroll.professional.ucsb.edu/
+- Validate layout consistency, branding, language, and ADA compliance.
+- Optional OpenAI integration for AI-assisted checks.
+
+## Usage
+Install dependencies and run the audit:
+```bash
+pip install -e .[test]
+pace-aid crawl --limit 10
+```
+
+## Tests
+Run unit tests using `pytest`:
+```bash
+pytest
+```
+
+## License
+Internal use only.

--- a/pace_aid/__init__.py
+++ b/pace_aid/__init__.py
@@ -1,0 +1,9 @@
+"""PacE AID package."""
+
+__all__ = [
+    "config",
+    "crawler",
+    "indexer",
+    "audit",
+    "openai_utils",
+]

--- a/pace_aid/audit.py
+++ b/pace_aid/audit.py
@@ -1,0 +1,86 @@
+"""Auditing utilities for pages."""
+
+from __future__ import annotations
+
+import re
+from typing import List, Tuple
+
+from bs4 import BeautifulSoup
+from wcag_contrast_ratio import rgb
+
+from .indexer import Page
+from .openai_utils import summarize_text
+
+# Example brand colors (hex) from the provided spreadsheet
+BRAND_COLORS = {
+    "#003660",  # UCSB blue
+    "#FFCD00",  # yellow
+    "#FFFFFF",  # white
+}
+
+
+def _hex_to_rgb(value: str) -> Tuple[float, float, float]:
+    value = value.lstrip("#")
+    if len(value) == 3:
+        value = "".join(ch * 2 for ch in value)
+    r = int(value[0:2], 16) / 255.0
+    g = int(value[2:4], 16) / 255.0
+    b = int(value[4:6], 16) / 255.0
+    return r, g, b
+
+
+def check_layout(page: Page) -> bool:
+    """Check that header and footer exist."""
+    soup = BeautifulSoup(page.html, "html.parser")
+    return bool(soup.find("header") and soup.find("footer"))
+
+
+def check_alt_text(page: Page) -> bool:
+    soup = BeautifulSoup(page.html, "html.parser")
+    images = soup.find_all("img")
+    return all(img.has_attr("alt") and img["alt"].strip() for img in images)
+
+
+def check_brand_colors(page: Page) -> bool:
+    soup = BeautifulSoup(page.html, "html.parser")
+    colors_in_page = set()
+    for tag in soup.find_all(style=True):
+        styles = tag["style"].split(";")
+        for style in styles:
+            if "color" in style or "background" in style:
+                match = re.search(r"#(?:[0-9a-fA-F]{3}){1,2}", style)
+                if match:
+                    colors_in_page.add(match.group(0).lower())
+    return bool(colors_in_page & {c.lower() for c in BRAND_COLORS})
+
+
+def check_contrast(page: Page) -> bool:
+    soup = BeautifulSoup(page.html, "html.parser")
+    for tag in soup.find_all(style=True):
+        fg_match = re.search(r"color:\s*(#[0-9a-fA-F]{6})", tag["style"])
+        bg_match = re.search(r"background(?:-color)?:\s*(#[0-9a-fA-F]{6})", tag["style"])
+        if fg_match and bg_match:
+            fg = _hex_to_rgb(fg_match.group(1))
+            bg = _hex_to_rgb(bg_match.group(1))
+            ratio = rgb(fg, bg)
+            if ratio < 4.5:
+                return False
+    return True
+
+
+def summarize(page: Page) -> str:
+    return summarize_text(page.text)
+
+
+def run_audits(page: Page) -> List[str]:
+    """Run all audits and return list of failed checks."""
+    failures: List[str] = []
+    if not check_layout(page):
+        failures.append("layout")
+    if not check_alt_text(page):
+        failures.append("alt_text")
+    if not check_brand_colors(page):
+        failures.append("brand_colors")
+    if not check_contrast(page):
+        failures.append("contrast")
+    return failures

--- a/pace_aid/config.py
+++ b/pace_aid/config.py
@@ -1,0 +1,16 @@
+"""Configuration for the PacE AID tool."""
+
+from dataclasses import dataclass
+from typing import List
+
+@dataclass
+class SiteConfig:
+    url: str
+    category: str
+
+# Default configuration for the three domains
+DEFAULT_SITES: List[SiteConfig] = [
+    SiteConfig(url="https://www.professional.ucsb.edu/", category="Website"),
+    SiteConfig(url="https://enroll.professional.ucsb.edu/", category="Course Pages"),
+    SiteConfig(url="https://help.professional.ucsb.edu/", category="Help Desk"),
+]

--- a/pace_aid/crawler.py
+++ b/pace_aid/crawler.py
@@ -1,0 +1,61 @@
+"""Website crawler used to fetch and index pages."""
+
+from __future__ import annotations
+
+import re
+from collections import deque
+from dataclasses import dataclass
+from typing import Iterable, Optional, Set
+from urllib.parse import urljoin, urlparse
+
+import requests
+from bs4 import BeautifulSoup
+
+from .config import SiteConfig
+from .indexer import Index, Page
+
+
+@dataclass
+class Crawler:
+    site: SiteConfig
+    index: Index
+    visited: Set[str] = None
+
+    def __post_init__(self) -> None:
+        if self.visited is None:
+            self.visited = set()
+
+    def crawl(self, limit: Optional[int] = None) -> None:
+        """Crawl pages starting from the site's root URL."""
+        queue = deque([self.site.url])
+        while queue:
+            url = queue.popleft()
+            if url in self.visited:
+                continue
+            self.visited.add(url)
+            try:
+                resp = requests.get(url, timeout=10)
+                resp.raise_for_status()
+            except requests.RequestException:
+                continue
+            soup = BeautifulSoup(resp.text, "html.parser")
+            text = soup.get_text(separator=" ", strip=True)
+            page = Page(url=url, html=resp.text, text=text, category=self.site.category)
+            self.index.add_page(page)
+            if limit and len(self.visited) >= limit:
+                break
+            for link in self._extract_links(soup, url):
+                if link not in self.visited:
+                    queue.append(link)
+
+    def _extract_links(self, soup: BeautifulSoup, base_url: str) -> Iterable[str]:
+        domain = urlparse(self.site.url).netloc
+        for a in soup.find_all("a", href=True):
+            href = a["href"]
+            href = urljoin(base_url, href)
+            parsed = urlparse(href)
+            if parsed.netloc != domain:
+                continue
+            if re.match(r"^mailto:|^tel:", href):
+                continue
+            yield href

--- a/pace_aid/indexer.py
+++ b/pace_aid/indexer.py
@@ -1,0 +1,21 @@
+"""Simple in-memory index used for storing crawled pages."""
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+@dataclass
+class Page:
+    url: str
+    html: str
+    text: str
+    category: str
+
+@dataclass
+class Index:
+    pages: Dict[str, Page] = field(default_factory=dict)
+
+    def add_page(self, page: Page) -> None:
+        self.pages[page.url] = page
+
+    def get_pages(self) -> List[Page]:
+        return list(self.pages.values())

--- a/pace_aid/main.py
+++ b/pace_aid/main.py
@@ -1,0 +1,42 @@
+"""Command line interface for PacE AID."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .config import DEFAULT_SITES
+from .crawler import Crawler
+from .indexer import Index
+from .audit import run_audits, summarize
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="PacE AID website auditor")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    crawl_p = subparsers.add_parser("crawl", help="Crawl websites")
+    crawl_p.add_argument("--limit", type=int, default=20, help="Page limit per site")
+    crawl_p.add_argument("--out", type=Path, default=Path("index.json"), help="Output file")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "crawl":
+        index = Index()
+        for site in DEFAULT_SITES:
+            crawler = Crawler(site=site, index=index)
+            crawler.crawl(limit=args.limit)
+        data = {
+            url: {
+                "category": p.category,
+                "summary": summarize(p),
+                "failures": run_audits(p),
+            }
+            for url, p in index.pages.items()
+        }
+        args.out.write_text(json.dumps(data, indent=2))
+        print(f"Wrote results to {args.out}")
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/pace_aid/openai_utils.py
+++ b/pace_aid/openai_utils.py
@@ -1,0 +1,26 @@
+"""Utility functions for OpenAI integration."""
+
+import os
+from typing import Optional
+
+try:
+    import openai
+except Exception:  # pragma: no cover - optional dependency
+    openai = None  # type: ignore
+
+
+def summarize_text(text: str) -> str:
+    """Return a short summary of the given text using OpenAI if API key is set."""
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key or not openai:
+        return ""
+    openai.api_key = api_key
+    try:
+        resp = openai.chat.completions.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "system", "content": "Summarize the following text."}, {"role": "user", "content": text[:4000]}],
+            max_tokens=60,
+        )
+        return resp.choices[0].message.content.strip()
+    except Exception:
+        return ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "pace_aid"
+version = "0.1.0"
+description = "UCSB PaCE website auditing tool"
+requires-python = ">=3.10"
+authors = [{name="UCSB PaCE"}]
+dependencies = [
+    "requests",
+    "beautifulsoup4",
+    "openai",
+    "wcag-contrast-ratio"
+]
+
+[project.optional-dependencies]
+test = ["pytest", "responses"]
+
+[project.scripts]
+pace-aid = "pace_aid.main:main"
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,18 @@
+from pace_aid.indexer import Page
+from pace_aid import audit
+
+SIMPLE_HTML = """
+<html>
+  <header></header>
+  <body>
+    <img src='x.png' alt='desc'>
+    <div style='color:#FFFFFF;background:#003660'>Text</div>
+  </body>
+  <footer></footer>
+</html>
+"""
+
+page = Page(url='https://example.com', html=SIMPLE_HTML, text='Text', category='Website')
+
+def test_run_audits():
+    assert audit.run_audits(page) == []

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1,0 +1,18 @@
+import responses
+from pace_aid.crawler import Crawler
+from pace_aid.config import SiteConfig
+from pace_aid.indexer import Index
+
+
+@responses.activate
+def test_crawl_single_page():
+    html = "<html><body><a href='/a'>A</a></body></html>"
+    responses.add(responses.GET, 'https://example.com/', body=html, status=200)
+    responses.add(responses.GET, 'https://example.com/a', body=html, status=200)
+
+    site = SiteConfig(url='https://example.com/', category='Website')
+    index = Index()
+    crawler = Crawler(site=site, index=index)
+    crawler.crawl(limit=2)
+
+    assert len(index.pages) == 2


### PR DESCRIPTION
## Summary
- add Python package `pace_aid` with crawler and auditing utilities
- provide CLI entrypoint `pace-aid` for crawling and auditing the PaCE sites
- implement optional OpenAI integration
- add unit tests and GitHub Actions workflow
- document usage in README

## Testing
- `pip install -e .[test]`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6868dc499e6083339c4b54c53e9d6b84