### PR TITLE
Add dashboard support and project guidelines

### DIFF
--- a/.github/copilot.yml
+++ b/.github/copilot.yml
@@ -8,5 +8,6 @@ instructions: |
   and are listed in ``pace_aid/brand.py``. Logos may appear as inline SVG images
   using data URIs, which are accepted sources. The code should remain modular,
   transparent and professionally documented. Use safe, reliable libraries and
-  keep the testing pipeline green. Output JSON and an HTML dashboard summarizing
-  audit results.
+  keep the testing pipeline green. Set ``OPENAI_API_KEY`` in the environment to
+  enable text summarization via OpenAI. Output JSON and an HTML dashboard
+  summarizing audit results.

--- a/.github/copilot.yml
+++ b/.github/copilot.yml
@@ -9,5 +9,6 @@ instructions: |
   using data URIs, which are accepted sources. The code should remain modular,
   transparent and professionally documented. Use safe, reliable libraries and
   keep the testing pipeline green. Set ``OPENAI_API_KEY`` in the environment to
-  enable text summarization via OpenAI. Output JSON and an HTML dashboard
+  enable text summarization and brand voice checks via OpenAI. Use the API
+  conservatively to minimize costs. Output JSON and an HTML dashboard
   summarizing audit results.

--- a/.github/copilot.yml
+++ b/.github/copilot.yml
@@ -1,0 +1,8 @@
+version: 1
+instructions: |
+  This repository contains PacE AID, an internal auditing tool for UCSB PaCE.
+  It crawls three PaCE web domains, indexes all pages and audits them for layout
+  consistency, language, branding (colors, pictures, logo), ADA compliance and
+  other UCSB PaCE policies. The code should remain modular, transparent and
+  professionally documented. Use safe, reliable libraries and keep the testing
+  pipeline green. Output JSON and an HTML dashboard summarizing audit results.

--- a/.github/copilot.yml
+++ b/.github/copilot.yml
@@ -3,6 +3,9 @@ instructions: |
   This repository contains PacE AID, an internal auditing tool for UCSB PaCE.
   It crawls three PaCE web domains, indexes all pages and audits them for layout
   consistency, language, branding (colors, pictures, logo), ADA compliance and
-  other UCSB PaCE policies. The code should remain modular, transparent and
-  professionally documented. Use safe, reliable libraries and keep the testing
-  pipeline green. Output JSON and an HTML dashboard summarizing audit results.
+  other UCSB PaCE policies. Approved brand colors and logos come from the
+  spreadsheet at https://docs.google.com/spreadsheets/d/e/2PACX-1vSzhsMRhe-VVLFfa89R9aUNJ58dIvGCMF41QWiOig4wqZHMJJ4_xDVql11siefnc3stU17WyFqbUeLb/pubhtml
+  and are listed in ``pace_aid/brand.py``. The code should remain modular,
+  transparent and professionally documented. Use safe, reliable libraries and
+  keep the testing pipeline green. Output JSON and an HTML dashboard summarizing
+  audit results.

--- a/.github/copilot.yml
+++ b/.github/copilot.yml
@@ -5,7 +5,8 @@ instructions: |
   consistency, language, branding (colors, pictures, logo), ADA compliance and
   other UCSB PaCE policies. Approved brand colors and logos come from the
   spreadsheet at https://docs.google.com/spreadsheets/d/e/2PACX-1vSzhsMRhe-VVLFfa89R9aUNJ58dIvGCMF41QWiOig4wqZHMJJ4_xDVql11siefnc3stU17WyFqbUeLb/pubhtml
-  and are listed in ``pace_aid/brand.py``. The code should remain modular,
+  and are listed in ``pace_aid/brand.py``. Logos may appear as inline SVG images
+  using data URIs, which are accepted sources. The code should remain modular,
   transparent and professionally documented. Use safe, reliable libraries and
   keep the testing pipeline green. Output JSON and an HTML dashboard summarizing
   audit results.

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,18 @@
+name: Python package
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[test]
+      - name: Run tests
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+
+# Env
+venv/
+.env
+
+# Data
+index.json

--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ Install dependencies and run the audit:
 pip install -e .[test]
 pace-aid crawl --limit 10 --dashboard report.html
 ```
-To enable OpenAI features like summarization and brand voice checks, set the
-`OPENAI_API_KEY` environment variable before running the tool. Use the API
+OpenAI functionality such as summarization and brand voice validation requires
+the `OPENAI_API_KEY` environment variable. If the key is not set or the OpenAI
+package is unavailable, the tool will raise an error. Use the API
 conservatively to manage costs.
 
 ## Tests

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ PacE AID (Artificial Intelligence Dean) is a tool for crawling and auditing the 
   - https://enroll.professional.ucsb.edu/ (Course Pages)
   - https://help.professional.ucsb.edu/ (Help Desk)
 - Validate layout consistency, branding, language, and ADA compliance.
-- Check that pages include a single top-level heading and a meta description tag.
+- Check that pages include a single top-level heading, a meta description tag, and approved logos.
 - Optional OpenAI integration for AI-assisted checks.
 - Output a live HTML dashboard summarizing audit results.
 
@@ -32,7 +32,7 @@ Internal use only.
 
 ### Current features
 - Crawl specified PaCE domains and build an index
-- Validate layout, alt text, headings, meta descriptions, brand colors, and contrast
+- Validate layout, alt text, headings, meta descriptions, brand colors, logo usage, and contrast
 - Summarize page text with optional OpenAI integration
 - Export results to JSON and an HTML dashboard
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Install dependencies and run the audit:
 pip install -e .[test]
 pace-aid crawl --limit 10 --dashboard report.html
 ```
+To enable page summarization with OpenAI, set the `OPENAI_API_KEY` environment
+variable before running the tool.
 
 ## Tests
 Run unit tests using `pytest`:

--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
 # PacE Web Audit
 
-PacE AID (Artificial Intelligence Dean) is a tool for crawling and auditing the UCSB Professional and Continuing Education websites. It indexes pages from the three PaCE domains and evaluates them for branding and compliance issues using reliable, well-tested libraries. The goal is a modular, transparent system suitable for internal use.
+PacE AID (Artificial Intelligence Dean) crawls the three PaCE domains and indexes every page. It validates layout, brand voice and accessibility using safe, modern libraries. The project is modular, thoroughly tested and intended for internal use only.
 
 ## Features
 - **Crawling targets**
   - https://www.professional.ucsb.edu/ (Website)
   - https://enroll.professional.ucsb.edu/ (Course Pages)
   - https://help.professional.ucsb.edu/ (Help Desk)
-- Validate layout consistency, branding, language, and ADA compliance.
-- Check that pages include a single top-level heading, a meta description tag, and approved logos.
-- Optional OpenAI integration for AI-assisted checks.
-- Output a live HTML dashboard summarizing audit results.
+- Parse and index the Website, Course Pages and Help Desk domains.
+- Validate layout consistency, brand voice and ADA compliance.
+- Ensure approved brand colors and logos are used. Inline SVG logos with data URIs are accepted.
+- Check that each page includes one H1 heading and a meta description tag.
+- Optional OpenAI integration for AI-assisted checks such as summarization.
+- Output JSON data and a live HTML dashboard summarizing audit results.
 
 ## Usage
 Install dependencies and run the audit:

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ PacE AID (Artificial Intelligence Dean) crawls the three PaCE domains and indexe
   - https://enroll.professional.ucsb.edu/ (Course Pages)
   - https://help.professional.ucsb.edu/ (Help Desk)
 - Parse and index the Website, Course Pages and Help Desk domains.
-- Validate layout consistency, brand voice and ADA compliance.
+ - Validate layout consistency, brand voice and ADA compliance.
 - Ensure approved brand colors and logos are used. Inline SVG logos with data URIs are accepted.
 - Check that each page includes one H1 heading and a meta description tag.
-- Optional OpenAI integration for AI-assisted checks such as summarization.
+ - Optional OpenAI integration for AI-assisted checks such as summarization and brand voice validation.
 - Output JSON data and a live HTML dashboard summarizing audit results.
 
 ## Usage
@@ -20,8 +20,9 @@ Install dependencies and run the audit:
 pip install -e .[test]
 pace-aid crawl --limit 10 --dashboard report.html
 ```
-To enable page summarization with OpenAI, set the `OPENAI_API_KEY` environment
-variable before running the tool.
+To enable OpenAI features like summarization and brand voice checks, set the
+`OPENAI_API_KEY` environment variable before running the tool. Use the API
+conservatively to manage costs.
 
 ## Tests
 Run unit tests using `pytest`:
@@ -37,7 +38,7 @@ Internal use only.
 ### Current features
 - Crawl specified PaCE domains and build an index
 - Validate layout, alt text, headings, meta descriptions, brand colors, logo usage, and contrast
-- Summarize page text with optional OpenAI integration
+- Summarize page text and check brand voice with optional OpenAI integration
 - Export results to JSON and an HTML dashboard
 
 ### Most important feature

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ PacE AID (Artificial Intelligence Dean) is a tool for crawling and auditing the 
   - https://enroll.professional.ucsb.edu/ (Course Pages)
   - https://help.professional.ucsb.edu/ (Help Desk)
 - Validate layout consistency, branding, language, and ADA compliance.
-- Check that pages include a single top-level heading.
+- Check that pages include a single top-level heading and a meta description tag.
 - Optional OpenAI integration for AI-assisted checks.
 - Output a live HTML dashboard summarizing audit results.
 
@@ -32,7 +32,7 @@ Internal use only.
 
 ### Current features
 - Crawl specified PaCE domains and build an index
-- Validate layout, alt text, headings, brand colors, and contrast
+- Validate layout, alt text, headings, meta descriptions, brand colors, and contrast
 - Summarize page text with optional OpenAI integration
 - Export results to JSON and an HTML dashboard
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,51 @@
-# PacE_web_audit
+# PacE Web Audit
+
+PacE AID (Artificial Intelligence Dean) is a tool for crawling and auditing the UCSB Professional and Continuing Education websites. It indexes pages from the three PaCE domains and evaluates them for branding and compliance issues using reliable, well-tested libraries. The goal is a modular, transparent system suitable for internal use.
+
+## Features
+- **Crawling targets**
+  - https://www.professional.ucsb.edu/ (Website)
+  - https://enroll.professional.ucsb.edu/ (Course Pages)
+  - https://help.professional.ucsb.edu/ (Help Desk)
+- Validate layout consistency, branding, language, and ADA compliance.
+- Check that pages include a single top-level heading.
+- Optional OpenAI integration for AI-assisted checks.
+- Output a live HTML dashboard summarizing audit results.
+
+## Usage
+Install dependencies and run the audit:
+```bash
+pip install -e .[test]
+pace-aid crawl --limit 10 --dashboard report.html
+```
+
+## Tests
+Run unit tests using `pytest`:
+```bash
+pytest
+```
+
+## License
+Internal use only.
+
+## Project roadmap
+
+### Current features
+- Crawl specified PaCE domains and build an index
+- Validate layout, alt text, headings, brand colors, and contrast
+- Summarize page text with optional OpenAI integration
+- Export results to JSON and an HTML dashboard
+
+### Most important feature
+Automated auditing of every PaCE page to ensure branding and accessibility compliance.
+
+### MVP criteria
+- Crawl all three domains
+- Perform the set of audits listed above
+- Generate JSON and dashboard outputs
+- Provide a test suite and CI workflow
+
+### Next steps
+- Expand brand checks using the official spreadsheet
+- Integrate additional compliance policies from UCSB PaCE
+- Improve dashboard visualizations

--- a/pace_aid/__init__.py
+++ b/pace_aid/__init__.py
@@ -6,4 +6,5 @@ __all__ = [
     "indexer",
     "audit",
     "openai_utils",
+    "brand",
 ]

--- a/pace_aid/__init__.py
+++ b/pace_aid/__init__.py
@@ -1,0 +1,9 @@
+"""PacE AID package."""
+
+__all__ = [
+    "config",
+    "crawler",
+    "indexer",
+    "audit",
+    "openai_utils",
+]

--- a/pace_aid/audit.py
+++ b/pace_aid/audit.py
@@ -1,0 +1,95 @@
+"""Auditing utilities for pages."""
+
+from __future__ import annotations
+
+import re
+from typing import List, Tuple
+
+from bs4 import BeautifulSoup
+from wcag_contrast_ratio import rgb
+
+from .indexer import Page
+from .openai_utils import summarize_text
+
+# Example brand colors (hex) from the provided spreadsheet
+BRAND_COLORS = {
+    "#003660",  # UCSB blue
+    "#FFCD00",  # yellow
+    "#FFFFFF",  # white
+}
+
+
+def _hex_to_rgb(value: str) -> Tuple[float, float, float]:
+    value = value.lstrip("#")
+    if len(value) == 3:
+        value = "".join(ch * 2 for ch in value)
+    r = int(value[0:2], 16) / 255.0
+    g = int(value[2:4], 16) / 255.0
+    b = int(value[4:6], 16) / 255.0
+    return r, g, b
+
+
+def check_layout(page: Page) -> bool:
+    """Check that header and footer exist."""
+    soup = BeautifulSoup(page.html, "html.parser")
+    return bool(soup.find("header") and soup.find("footer"))
+
+
+def check_alt_text(page: Page) -> bool:
+    soup = BeautifulSoup(page.html, "html.parser")
+    images = soup.find_all("img")
+    return all(img.has_attr("alt") and img["alt"].strip() for img in images)
+
+
+def check_headings(page: Page) -> bool:
+    """Ensure exactly one H1 heading is present."""
+    soup = BeautifulSoup(page.html, "html.parser")
+    h1s = soup.find_all("h1")
+    return len(h1s) == 1
+
+
+def check_brand_colors(page: Page) -> bool:
+    soup = BeautifulSoup(page.html, "html.parser")
+    colors_in_page = set()
+    for tag in soup.find_all(style=True):
+        styles = tag["style"].split(";")
+        for style in styles:
+            if "color" in style or "background" in style:
+                match = re.search(r"#(?:[0-9a-fA-F]{3}){1,2}", style)
+                if match:
+                    colors_in_page.add(match.group(0).lower())
+    return bool(colors_in_page & {c.lower() for c in BRAND_COLORS})
+
+
+def check_contrast(page: Page) -> bool:
+    soup = BeautifulSoup(page.html, "html.parser")
+    for tag in soup.find_all(style=True):
+        fg_match = re.search(r"color:\s*(#[0-9a-fA-F]{6})", tag["style"])
+        bg_match = re.search(r"background(?:-color)?:\s*(#[0-9a-fA-F]{6})", tag["style"])
+        if fg_match and bg_match:
+            fg = _hex_to_rgb(fg_match.group(1))
+            bg = _hex_to_rgb(bg_match.group(1))
+            ratio = rgb(fg, bg)
+            if ratio < 4.5:
+                return False
+    return True
+
+
+def summarize(page: Page) -> str:
+    return summarize_text(page.text)
+
+
+def run_audits(page: Page) -> List[str]:
+    """Run all audits and return list of failed checks."""
+    failures: List[str] = []
+    if not check_layout(page):
+        failures.append("layout")
+    if not check_alt_text(page):
+        failures.append("alt_text")
+    if not check_headings(page):
+        failures.append("headings")
+    if not check_brand_colors(page):
+        failures.append("brand_colors")
+    if not check_contrast(page):
+        failures.append("contrast")
+    return failures

--- a/pace_aid/audit.py
+++ b/pace_aid/audit.py
@@ -75,6 +75,13 @@ def check_contrast(page: Page) -> bool:
     return True
 
 
+def check_meta_description(page: Page) -> bool:
+    """Ensure page has a meta description tag."""
+    soup = BeautifulSoup(page.html, "html.parser")
+    tag = soup.find("meta", attrs={"name": "description"})
+    return bool(tag and tag.get("content"))
+
+
 def summarize(page: Page) -> str:
     return summarize_text(page.text)
 
@@ -92,4 +99,6 @@ def run_audits(page: Page) -> List[str]:
         failures.append("brand_colors")
     if not check_contrast(page):
         failures.append("contrast")
+    if not check_meta_description(page):
+        failures.append("meta_description")
     return failures

--- a/pace_aid/audit.py
+++ b/pace_aid/audit.py
@@ -10,13 +10,7 @@ from wcag_contrast_ratio import rgb
 
 from .indexer import Page
 from .openai_utils import summarize_text
-
-# Example brand colors (hex) from the provided spreadsheet
-BRAND_COLORS = {
-    "#003660",  # UCSB blue
-    "#FFCD00",  # yellow
-    "#FFFFFF",  # white
-}
+from .brand import BRAND_COLORS, LOGO_URLS
 
 
 def _hex_to_rgb(value: str) -> Tuple[float, float, float]:
@@ -75,6 +69,18 @@ def check_contrast(page: Page) -> bool:
     return True
 
 
+def check_logos(page: Page) -> bool:
+    """Ensure any logo images use approved sources."""
+    soup = BeautifulSoup(page.html, "html.parser")
+    logos = [img["src"] for img in soup.find_all("img", src=True) if "logo" in img["src"].lower()]
+    if not logos:
+        return True
+    for src in logos:
+        if not any(src.startswith(url) for url in LOGO_URLS):
+            return False
+    return True
+
+
 def check_meta_description(page: Page) -> bool:
     """Ensure page has a meta description tag."""
     soup = BeautifulSoup(page.html, "html.parser")
@@ -99,6 +105,8 @@ def run_audits(page: Page) -> List[str]:
         failures.append("brand_colors")
     if not check_contrast(page):
         failures.append("contrast")
+    if not check_logos(page):
+        failures.append("logos")
     if not check_meta_description(page):
         failures.append("meta_description")
     return failures

--- a/pace_aid/audit.py
+++ b/pace_aid/audit.py
@@ -9,7 +9,7 @@ from bs4 import BeautifulSoup
 from wcag_contrast_ratio import rgb
 
 from .indexer import Page
-from .openai_utils import summarize_text
+from .openai_utils import summarize_text, brand_voice_consistent
 from .brand import BRAND_COLORS, LOGO_SOURCES
 
 
@@ -101,6 +101,11 @@ def check_meta_description(page: Page) -> bool:
     return bool(tag and tag.get("content"))
 
 
+def check_brand_voice(page: Page) -> bool:
+    """Use OpenAI to ensure text matches the PaCE brand voice."""
+    return brand_voice_consistent(page.text)
+
+
 def summarize(page: Page) -> str:
     return summarize_text(page.text)
 
@@ -112,6 +117,8 @@ def run_audits(page: Page) -> List[str]:
         failures.append("layout")
     if not check_alt_text(page):
         failures.append("alt_text")
+    if not check_brand_voice(page):
+        failures.append("brand_voice")
     if not check_headings(page):
         failures.append("headings")
     if not check_brand_colors(page):

--- a/pace_aid/brand.py
+++ b/pace_aid/brand.py
@@ -7,8 +7,8 @@ BRAND_COLORS = {
     "#febc11",  # UCSB Gold
 }
 
-# Approved logo image URLs
-LOGO_URLS = [
+# Approved logo image URLs and allowed prefixes
+LOGO_SOURCES = [
     "https://www.professional.ucsb.edu/sites/default/files/2025-05/Logo_PaCE_2025_Full.png",
     "https://www.professional.ucsb.edu/sites/default/files/2025-05/Logo_IP_2025_Full.png",
     "https://www.professional.ucsb.edu/sites/default/files/2025-05/Logo_PaCE_2025_Full_White_0.png",
@@ -17,4 +17,6 @@ LOGO_URLS = [
     "https://www.professional.ucsb.edu/sites/default/files/2025-05/Logo_IP_2025_Full_Black.png",
     "https://www.professional.ucsb.edu/sites/default/files/2025-05/Logo_PaCE_2025_Short.png",
     "https://www.professional.ucsb.edu/sites/default/files/2025-05/Logo_IP_2025_Short.png",
+    "data:image/svg+xml",
+    "data:image/png;base64",
 ]

--- a/pace_aid/brand.py
+++ b/pace_aid/brand.py
@@ -1,0 +1,20 @@
+"""Branding data constants for UCSB PaCE."""
+
+# Hex color codes from the official branding spreadsheet
+BRAND_COLORS = {
+    "#1178b5",  # PaCE Blue
+    "#003660",  # UCSB Blue
+    "#febc11",  # UCSB Gold
+}
+
+# Approved logo image URLs
+LOGO_URLS = [
+    "https://www.professional.ucsb.edu/sites/default/files/2025-05/Logo_PaCE_2025_Full.png",
+    "https://www.professional.ucsb.edu/sites/default/files/2025-05/Logo_IP_2025_Full.png",
+    "https://www.professional.ucsb.edu/sites/default/files/2025-05/Logo_PaCE_2025_Full_White_0.png",
+    "https://www.professional.ucsb.edu/sites/default/files/2025-05/Logo_PaCE_2025_Full_Black.png",
+    "https://www.professional.ucsb.edu/sites/default/files/2025-05/Logo_IP_2025_Full_White.png",
+    "https://www.professional.ucsb.edu/sites/default/files/2025-05/Logo_IP_2025_Full_Black.png",
+    "https://www.professional.ucsb.edu/sites/default/files/2025-05/Logo_PaCE_2025_Short.png",
+    "https://www.professional.ucsb.edu/sites/default/files/2025-05/Logo_IP_2025_Short.png",
+]

--- a/pace_aid/config.py
+++ b/pace_aid/config.py
@@ -1,0 +1,16 @@
+"""Configuration for the PacE AID tool."""
+
+from dataclasses import dataclass
+from typing import List
+
+@dataclass
+class SiteConfig:
+    url: str
+    category: str
+
+# Default configuration for the three domains
+DEFAULT_SITES: List[SiteConfig] = [
+    SiteConfig(url="https://www.professional.ucsb.edu/", category="Website"),
+    SiteConfig(url="https://enroll.professional.ucsb.edu/", category="Course Pages"),
+    SiteConfig(url="https://help.professional.ucsb.edu/", category="Help Desk"),
+]

--- a/pace_aid/crawler.py
+++ b/pace_aid/crawler.py
@@ -1,0 +1,61 @@
+"""Website crawler used to fetch and index pages."""
+
+from __future__ import annotations
+
+import re
+from collections import deque
+from dataclasses import dataclass
+from typing import Iterable, Optional, Set
+from urllib.parse import urljoin, urlparse
+
+import requests
+from bs4 import BeautifulSoup
+
+from .config import SiteConfig
+from .indexer import Index, Page
+
+
+@dataclass
+class Crawler:
+    site: SiteConfig
+    index: Index
+    visited: Set[str] = None
+
+    def __post_init__(self) -> None:
+        if self.visited is None:
+            self.visited = set()
+
+    def crawl(self, limit: Optional[int] = None) -> None:
+        """Crawl pages starting from the site's root URL."""
+        queue = deque([self.site.url])
+        while queue:
+            url = queue.popleft()
+            if url in self.visited:
+                continue
+            self.visited.add(url)
+            try:
+                resp = requests.get(url, timeout=10)
+                resp.raise_for_status()
+            except requests.RequestException:
+                continue
+            soup = BeautifulSoup(resp.text, "html.parser")
+            text = soup.get_text(separator=" ", strip=True)
+            page = Page(url=url, html=resp.text, text=text, category=self.site.category)
+            self.index.add_page(page)
+            if limit and len(self.visited) >= limit:
+                break
+            for link in self._extract_links(soup, url):
+                if link not in self.visited:
+                    queue.append(link)
+
+    def _extract_links(self, soup: BeautifulSoup, base_url: str) -> Iterable[str]:
+        domain = urlparse(self.site.url).netloc
+        for a in soup.find_all("a", href=True):
+            href = a["href"]
+            href = urljoin(base_url, href)
+            parsed = urlparse(href)
+            if parsed.netloc != domain:
+                continue
+            if re.match(r"^mailto:|^tel:", href):
+                continue
+            yield href

--- a/pace_aid/indexer.py
+++ b/pace_aid/indexer.py
@@ -1,0 +1,21 @@
+"""Simple in-memory index used for storing crawled pages."""
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+@dataclass
+class Page:
+    url: str
+    html: str
+    text: str
+    category: str
+
+@dataclass
+class Index:
+    pages: Dict[str, Page] = field(default_factory=dict)
+
+    def add_page(self, page: Page) -> None:
+        self.pages[page.url] = page
+
+    def get_pages(self) -> List[Page]:
+        return list(self.pages.values())

--- a/pace_aid/main.py
+++ b/pace_aid/main.py
@@ -1,0 +1,67 @@
+"""Command line interface for PacE AID."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from typing import Dict, Any
+
+from .config import DEFAULT_SITES
+from .crawler import Crawler
+from .indexer import Index
+from .audit import run_audits, summarize
+
+
+def write_dashboard(data: Dict[str, Any], out: Path) -> None:
+    """Write a simple HTML dashboard summarizing audit results."""
+    rows = []
+    for url, entry in data.items():
+        failures = ", ".join(entry["failures"]) if entry["failures"] else ""
+        rows.append(
+            f"<tr><td><a href='{url}'>{url}</a></td><td>{entry['category']}</td>"
+            f"<td>{failures}</td><td>{entry['summary']}</td></tr>"
+        )
+    html = (
+        "<html><head><title>PacE AID Dashboard</title></head><body>"
+        "<h1>PacE AID Report</h1><table border='1'>"
+        "<tr><th>URL</th><th>Category</th><th>Failures</th><th>Summary</th></tr>"
+        + "".join(rows)
+        + "</table></body></html>"
+    )
+    out.write_text(html)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="PacE AID website auditor")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    crawl_p = subparsers.add_parser("crawl", help="Crawl websites")
+    crawl_p.add_argument("--limit", type=int, default=20, help="Page limit per site")
+    crawl_p.add_argument("--out", type=Path, default=Path("index.json"), help="Output JSON file")
+    crawl_p.add_argument("--dashboard", type=Path, help="Optional HTML dashboard output")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "crawl":
+        index = Index()
+        for site in DEFAULT_SITES:
+            crawler = Crawler(site=site, index=index)
+            crawler.crawl(limit=args.limit)
+        data = {
+            url: {
+                "category": p.category,
+                "summary": summarize(p),
+                "failures": run_audits(p),
+            }
+            for url, p in index.pages.items()
+        }
+        args.out.write_text(json.dumps(data, indent=2))
+        print(f"Wrote results to {args.out}")
+        if args.dashboard:
+            write_dashboard(data, args.dashboard)
+            print(f"Wrote dashboard to {args.dashboard}")
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/pace_aid/openai_utils.py
+++ b/pace_aid/openai_utils.py
@@ -3,37 +3,44 @@
 import os
 from typing import Optional
 
+openai: Optional[object]
+
 try:
     import openai
 except Exception:  # pragma: no cover - optional dependency
     openai = None  # type: ignore
 
 
-def summarize_text(text: str) -> str:
-    """Return a short summary of the given text using OpenAI if API key is set."""
+def _require_openai() -> object:
+    """Return the OpenAI module after verifying configuration."""
+    if openai is None:
+        raise RuntimeError("openai package is not installed")
     api_key = os.getenv("OPENAI_API_KEY")
-    if not api_key or not openai:
-        return ""
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY environment variable is not set")
     openai.api_key = api_key
+    return openai
+
+
+def summarize_text(text: str) -> str:
+    """Return a short summary of the given text using OpenAI."""
+    oai = _require_openai()
     try:
-        resp = openai.chat.completions.create(
+        resp = oai.chat.completions.create(
             model="gpt-3.5-turbo",
             messages=[{"role": "system", "content": "Summarize the following text."}, {"role": "user", "content": text[:4000]}],
             max_tokens=60,
         )
         return resp.choices[0].message.content.strip()
     except Exception:
-        return ""
+        raise RuntimeError("OpenAI request failed")
 
 
 def brand_voice_consistent(text: str) -> bool:
     """Return True if text matches the UCSB PaCE brand voice using OpenAI."""
-    api_key = os.getenv("OPENAI_API_KEY")
-    if not api_key or not openai:
-        return True
-    openai.api_key = api_key
+    oai = _require_openai()
     try:
-        resp = openai.chat.completions.create(
+        resp = oai.chat.completions.create(
             model="gpt-3.5-turbo",
             messages=[
                 {
@@ -51,4 +58,4 @@ def brand_voice_consistent(text: str) -> bool:
         answer = resp.choices[0].message.content.strip().lower()
         return answer.startswith("y")
     except Exception:
-        return True
+        raise RuntimeError("OpenAI request failed")

--- a/pace_aid/openai_utils.py
+++ b/pace_aid/openai_utils.py
@@ -1,0 +1,26 @@
+"""Utility functions for OpenAI integration."""
+
+import os
+from typing import Optional
+
+try:
+    import openai
+except Exception:  # pragma: no cover - optional dependency
+    openai = None  # type: ignore
+
+
+def summarize_text(text: str) -> str:
+    """Return a short summary of the given text using OpenAI if API key is set."""
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key or not openai:
+        return ""
+    openai.api_key = api_key
+    try:
+        resp = openai.chat.completions.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "system", "content": "Summarize the following text."}, {"role": "user", "content": text[:4000]}],
+            max_tokens=60,
+        )
+        return resp.choices[0].message.content.strip()
+    except Exception:
+        return ""

--- a/pace_aid/openai_utils.py
+++ b/pace_aid/openai_utils.py
@@ -24,3 +24,31 @@ def summarize_text(text: str) -> str:
         return resp.choices[0].message.content.strip()
     except Exception:
         return ""
+
+
+def brand_voice_consistent(text: str) -> bool:
+    """Return True if text matches the UCSB PaCE brand voice using OpenAI."""
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key or not openai:
+        return True
+    openai.api_key = api_key
+    try:
+        resp = openai.chat.completions.create(
+            model="gpt-3.5-turbo",
+            messages=[
+                {
+                    "role": "system",
+                    "content": (
+                        "You check if the following text matches the UCSB PaCE brand voice."
+                        " Reply with 'Yes' or 'No' only."
+                    ),
+                },
+                {"role": "user", "content": text[:4000]},
+            ],
+            max_tokens=1,
+            temperature=0,
+        )
+        answer = resp.choices[0].message.content.strip().lower()
+        return answer.startswith("y")
+    except Exception:
+        return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "pace_aid"
+version = "0.1.0"
+description = "UCSB PaCE website auditing tool"
+requires-python = ">=3.10"
+authors = [{name="UCSB PaCE"}]
+dependencies = [
+    "requests",
+    "beautifulsoup4",
+    "openai",
+    "wcag-contrast-ratio"
+]
+
+[project.optional-dependencies]
+test = ["pytest", "responses"]
+
+[project.scripts]
+pace-aid = "pace_aid.main:main"
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -7,7 +7,7 @@ SIMPLE_HTML = """
   <header></header>
   <body>
     <h1>Title</h1>
-    <img src='x.png' alt='desc'>
+    <img src='https://www.professional.ucsb.edu/sites/default/files/2025-05/Logo_PaCE_2025_Full.png' alt='desc'>
     <div style='color:#FFFFFF;background:#003660'>Text</div>
   </body>
   <footer></footer>
@@ -30,3 +30,9 @@ def test_meta_description_missing():
     html = SIMPLE_HTML.replace("<meta name='description' content='desc'></meta>", '')
     bad_page = Page(url='https://bad.com', html=html, text='Text', category='Website')
     assert 'meta_description' in audit.run_audits(bad_page)
+
+
+def test_logo_check_fails():
+    html = SIMPLE_HTML.replace('Logo_PaCE_2025_Full.png', 'bad_logo.png')
+    bad_page = Page(url='https://bad.com', html=html, text='Text', category='Website')
+    assert 'logos' in audit.run_audits(bad_page)

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,25 @@
+from pace_aid.indexer import Page
+from pace_aid import audit
+
+SIMPLE_HTML = """
+<html>
+  <header></header>
+  <body>
+    <h1>Title</h1>
+    <img src='x.png' alt='desc'>
+    <div style='color:#FFFFFF;background:#003660'>Text</div>
+  </body>
+  <footer></footer>
+</html>
+"""
+
+page = Page(url='https://example.com', html=SIMPLE_HTML, text='Text', category='Website')
+
+def test_run_audits():
+    assert audit.run_audits(page) == []
+
+
+def test_headings_check_fails():
+    html = SIMPLE_HTML.replace('<h1>Title</h1>', '')
+    bad_page = Page(url='https://bad.com', html=html, text='Text', category='Website')
+    assert 'headings' in audit.run_audits(bad_page)

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -36,3 +36,12 @@ def test_logo_check_fails():
     html = SIMPLE_HTML.replace('Logo_PaCE_2025_Full.png', 'bad_logo.png')
     bad_page = Page(url='https://bad.com', html=html, text='Text', category='Website')
     assert 'logos' in audit.run_audits(bad_page)
+
+
+def test_logo_inline_svg_passes():
+    svg_html = SIMPLE_HTML.replace(
+        "<img src='https://www.professional.ucsb.edu/sites/default/files/2025-05/Logo_PaCE_2025_Full.png' alt='desc'>",
+        "<svg class='logo'><image xlink:href='data:image/svg+xml;base64,AAAA'/></svg>"
+    )
+    svg_page = Page(url='https://example.com', html=svg_html, text='Text', category='Website')
+    assert 'logos' not in audit.run_audits(svg_page)

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -16,7 +16,8 @@ SIMPLE_HTML = """
 
 page = Page(url='https://example.com', html=SIMPLE_HTML, text='Text', category='Website')
 
-def test_run_audits():
+def test_run_audits(monkeypatch):
+    monkeypatch.setattr(audit, "check_brand_voice", lambda page: True)
     assert audit.run_audits(page) == []
 
 
@@ -45,3 +46,11 @@ def test_logo_inline_svg_passes():
     )
     svg_page = Page(url='https://example.com', html=svg_html, text='Text', category='Website')
     assert 'logos' not in audit.run_audits(svg_page)
+
+
+def test_brand_voice_check_fails(monkeypatch):
+    def fake_brand_voice_consistent(text: str) -> bool:
+        return False
+
+    monkeypatch.setattr(audit, "check_brand_voice", lambda page: fake_brand_voice_consistent(page.text))
+    assert 'brand_voice' in audit.run_audits(page)

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -3,6 +3,7 @@ from pace_aid import audit
 
 SIMPLE_HTML = """
 <html>
+  <head><meta name='description' content='desc'></meta></head>
   <header></header>
   <body>
     <h1>Title</h1>
@@ -23,3 +24,9 @@ def test_headings_check_fails():
     html = SIMPLE_HTML.replace('<h1>Title</h1>', '')
     bad_page = Page(url='https://bad.com', html=html, text='Text', category='Website')
     assert 'headings' in audit.run_audits(bad_page)
+
+
+def test_meta_description_missing():
+    html = SIMPLE_HTML.replace("<meta name='description' content='desc'></meta>", '')
+    bad_page = Page(url='https://bad.com', html=html, text='Text', category='Website')
+    assert 'meta_description' in audit.run_audits(bad_page)

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1,0 +1,18 @@
+import responses
+from pace_aid.crawler import Crawler
+from pace_aid.config import SiteConfig
+from pace_aid.indexer import Index
+
+
+@responses.activate
+def test_crawl_single_page():
+    html = "<html><body><a href='/a'>A</a></body></html>"
+    responses.add(responses.GET, 'https://example.com/', body=html, status=200)
+    responses.add(responses.GET, 'https://example.com/a', body=html, status=200)
+
+    site = SiteConfig(url='https://example.com/', category='Website')
+    index = Index()
+    crawler = Crawler(site=site, index=index)
+    crawler.crawl(limit=2)
+
+    assert len(index.pages) == 2

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+from pace_aid.main import write_dashboard
+
+
+def test_write_dashboard(tmp_path: Path) -> None:
+    data = {
+        "https://example.com": {
+            "category": "Website",
+            "summary": "Summary",
+            "failures": ["layout"],
+        }
+    }
+    out = tmp_path / "dash.html"
+    write_dashboard(data, out)
+    html = out.read_text()
+    assert "<table" in html
+    assert "https://example.com" in html
+

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -1,0 +1,29 @@
+import types
+import pytest
+from pace_aid import openai_utils
+
+
+def test_require_key(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    with pytest.raises(RuntimeError):
+        openai_utils.summarize_text("text")
+
+
+def test_summarize(monkeypatch):
+    class FakeResp:
+        def __init__(self, content):
+            self.choices = [types.SimpleNamespace(message=types.SimpleNamespace(content=content))]
+
+    class FakeChat:
+        def __init__(self):
+            self.completions = types.SimpleNamespace(create=lambda **_: FakeResp("sum"))
+
+    class FakeOpenAI:
+        def __init__(self):
+            self.chat = FakeChat()
+            self.api_key = None
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    monkeypatch.setattr(openai_utils, "openai", FakeOpenAI())
+    assert openai_utils.summarize_text("text") == "sum"
+


### PR DESCRIPTION
## Summary
- implement optional HTML dashboard output in `main.py`
- document project vision and features in the README
- provide copilot instructions describing project goals
- add unit test for dashboard generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868dc499e6083339c4b54c53e9d6b84